### PR TITLE
Update serviceWorker.js

### DIFF
--- a/03-versioning/serviceWorker.js
+++ b/03-versioning/serviceWorker.js
@@ -88,7 +88,7 @@ self.addEventListener('fetch', event => {
     var request            = event.request;
     var url                = new URL(request.url);
     var criteria           = {
-      matchesPathPattern: !!(opts.cachePathPattern.exec(url.pathname),
+      matchesPathPattern: opts.cachePathPattern.test(url.pathname),
       isGETRequest      : request.method === 'GET',
       isFromMyOrigin    : url.origin === self.location.origin
     };


### PR DESCRIPTION
There is a small typo in `!!(opts.cachePathPattern.exec(url.pathname),` (a missing bracket). You could also write this using `RegExp.prototype.test` instead of `RegExp.prototype.exec` (saving the type conversion).
